### PR TITLE
dispatchEvent: send response to the callback function (possibly fixes…

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -587,12 +587,13 @@ exports.XMLHttpRequest = function() {
    * Dispatch any events, including both "on" methods and events attached using addEventListener.
    */
   this.dispatchEvent = function(event) {
+    var response={target: self}
     if (typeof self["on" + event] === "function") {
-      self["on" + event]();
+      self["on" + event](response);
     }
     if (event in listeners) {
       for (var i = 0, len = listeners[event].length; i < len; i++) {
-        listeners[event][i].call(self);
+        listeners[event][i].call(self,response);
       }
     }
   };


### PR DESCRIPTION
… #106)

I only needed `event.target` for my application. So if there are other properties that are helpful, feel free to add them.

Example:

```
req.addEventListener('load', function (e) { console.log(e.target) })
```
